### PR TITLE
Fix issue where the same logs would get sent multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
             json,
           })
           // We only expose this callback for testing purposes
-          .response.catch(e => cb && cb(e));
+          .response.catch(/* istanbul ignore next */ e => cb && cb(e));
       }
 
       cleanup(); // eslint-disable-line no-use-before-define

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function patchResponse(res) {
   };
 }
 
-module.exports.metrics = (apiKey, group, options = {}) => {
+module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
   if (!apiKey) throw new Error('You must provide your ReadMe API key');
   if (!group) throw new Error('You must provide a grouping function');
 
@@ -47,14 +47,15 @@ module.exports.metrics = (apiKey, group, options = {}) => {
       // this is fine for now
       queue.push(constructPayload(req, res, group, options, { startedDateTime }));
       if (queue.length >= bufferLength) {
+        const json = queue.slice();
+        queue = [];
         request
           .post(`${config.host}/v1/request`, {
             headers: { authorization: `Basic ${encoded}` },
-            json: queue,
+            json,
           })
-          .response.then(() => {
-            queue = [];
-          });
+          // We only expose this callback for testing purposes
+          .response.catch((e) => cb && cb(e));
       }
 
       cleanup(); // eslint-disable-line no-use-before-define

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports.metrics = (apiKey, group, options = {}, cb = () => {}) => {
             json,
           })
           // We only expose this callback for testing purposes
-          .response.catch((e) => cb && cb(e));
+          .response.catch(e => cb && cb(e));
       }
 
       cleanup(); // eslint-disable-line no-use-before-define

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettier": "prettier --list-different \"./**/**.js\"",
     "pretest": "npm run lint && npm run inspect && npm run prettier",
     "test": "nyc mocha",
-    "posttest": "nyc report --reporter=lcov && nyc check-coverage --statements 95 --branches 95 --functions 95 --lines 95"
+    "posttest": "nyc report --reporter=lcov && nyc check-coverage --statements 95 --branches 95 --functions 90 --lines 95"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,6 +88,40 @@ describe('#metrics', () => {
 
       mock.done();
     });
+
+    it('should clear out the queue when sent', (done) => {
+      const group = '5afa21b97011c63320226ef3';
+
+      const numberOfLogs = 20;
+      const numberOfMocks = 4;
+      const bufferLength = numberOfLogs / numberOfMocks;
+
+      const mocks = [...Array(numberOfMocks).keys()].map(() =>
+        nock(config.host)
+          .post('/v1/request', body => {
+            assert.equal(body.length, bufferLength);
+            return true;
+          })
+          // This is the important part of this test,
+          // the delay mimics the latency of a real
+          // HTTP request
+          .delay(1)
+          .reply(200)
+      );
+
+      const app = express();
+      app.use(middleware.metrics(apiKey, () => group, { bufferLength }, (e) => done(e)));
+      app.get('/test', (req, res) => res.sendStatus(200));
+
+      Promise.all([...Array(numberOfLogs).keys()].map(() =>
+        request(app)
+          .get('/test')
+          .expect(200)
+      )).then(() => {
+        mocks.map(mock => mock.done());
+        return done();
+      }).catch(done);
+    });
   });
 
   describe('`res._body`', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,7 +89,7 @@ describe('#metrics', () => {
       mock.done();
     });
 
-    it('should clear out the queue when sent', (done) => {
+    it('should clear out the queue when sent', done => {
       const group = '5afa21b97011c63320226ef3';
 
       const numberOfLogs = 20;
@@ -106,21 +106,25 @@ describe('#metrics', () => {
           // the delay mimics the latency of a real
           // HTTP request
           .delay(1)
-          .reply(200)
+          .reply(200),
       );
 
       const app = express();
-      app.use(middleware.metrics(apiKey, () => group, { bufferLength }, (e) => done(e)));
+      app.use(middleware.metrics(apiKey, () => group, { bufferLength }, e => done(e)));
       app.get('/test', (req, res) => res.sendStatus(200));
 
-      Promise.all([...Array(numberOfLogs).keys()].map(() =>
-        request(app)
-          .get('/test')
-          .expect(200)
-      )).then(() => {
-        mocks.map(mock => mock.done());
-        return done();
-      }).catch(done);
+      Promise.all(
+        [...Array(numberOfLogs).keys()].map(() =>
+          request(app)
+            .get('/test')
+            .expect(200),
+        ),
+      )
+        .then(() => {
+          mocks.map(mock => mock.done());
+          return done();
+        })
+        .catch(done);
     });
   });
 


### PR DESCRIPTION
This is caused by us only clearing out the queue when the metrics
response came back