### PR TITLE
Feature/x documentation url

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
   return (req, res, next) => {
     const startedDateTime = new Date();
     const logId = ObjectID();
-    res.setHeader('x-log-id', logId);
+    res.setHeader('x-readme-log', logId);
 
     patchResponse(res);
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const config = require('./config');
 const constructPayload = require('./lib/construct-payload');
 const createJWTLink = require('./lib/create-jwt-link');
 const getReadmeData = require('./lib/get-readme-data');
+const ObjectID = require("bson-objectid");
 
 // We're doing this to buffer up the response body
 // so we can send it off to the metrics server
@@ -39,13 +40,17 @@ module.exports.metrics = (apiKey, group, options = {}) => {
 
   return (req, res, next) => {
     const startedDateTime = new Date();
+    const logId = ObjectID();
+    res.setHeader('x-documentation-url', `https://dash.readme.io/logs/${logId}`);
+
     patchResponse(res);
 
     function send() {
       // This should in future become more sophisticated,
       // with flush timeouts and more error checking but
       // this is fine for now
-      queue.push(constructPayload(req, res, group, options, { startedDateTime }));
+      const payload = constructPayload(req, res, group, options, { startedDateTime, logId });
+      queue.push(payload);
       if (queue.length >= bufferLength) {
         request
           .post(`${config.host}/v1/request`, {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const config = require('./config');
 const constructPayload = require('./lib/construct-payload');
 const createJWTLink = require('./lib/create-jwt-link');
 const getReadmeData = require('./lib/get-readme-data');
-const ObjectID = require("bson-objectid");
+const ObjectID = require('bson-objectid');
 
 // We're doing this to buffer up the response body
 // so we can send it off to the metrics server

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports.metrics = (apiKey, group, options = {}) => {
   return (req, res, next) => {
     const startedDateTime = new Date();
     const logId = ObjectID();
-    res.setHeader('x-documentation-url', `https://dash.readme.io/logs/${logId}`);
+    res.setHeader('x-log-id', logId);
 
     patchResponse(res);
 

--- a/lib/construct-payload.js
+++ b/lib/construct-payload.js
@@ -3,7 +3,8 @@ const processRequest = require('./process-request');
 const processResponse = require('./process-response');
 const { name, version } = require('../package.json');
 
-module.exports = (req, res, group, options = {}, { startedDateTime }) => ({
+module.exports = (req, res, group, options = {}, { startedDateTime, logId }) => ({
+  _id: logId,
   group: group(req),
   clientIPAddress: req.ip,
   development: options.development,

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,6 +334,11 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "bson-objectid": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.3.0.tgz",
+      "integrity": "sha512-YcB+lRJEEEIcHNLKyhmHujW7OCVE3+xr9IpEhlprBZnXgF3hqeePeexIsAaOtu1SbkgZRlJVUxvYZ3ngUOyIew=="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1896,6 +1901,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2220,7 +2226,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2304,6 +2311,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2350,7 +2358,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2616,7 +2625,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "ReadMe.io integrations for Node",
   "version": "1.2.0",
   "dependencies": {
+    "bson-objectid": "^1.3.0",
     "configly": "^4.1.0",
     "jsonwebtoken": "^8.3.0",
     "lodash.omit": "^4.5.0",


### PR DESCRIPTION
What do you guys think about this flow?

1. End-user makes request
2. `readme-node` generates logId and URL
  - E.g. "https://dash.readme.io/logs/[GENERATED ID]" (we would need to create a new route)
3. End-user goes to said URL
4. End-user is routed to the hub of the associated project ([HUB_URL]/logs/:id)

Thoughts @mjcuva?


