### PR TITLE
Fix HTTP versioning in request payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Track your API metrics within ReadMe.
 
-[![CircleCI](https://circleci.com/gh/readmeio/readme-node.svg?style=svg)](https://circleci.com/gh/readmeio/readme-node)
+[![Build](https://github.com/readmeio/readme-node/workflows/Node%20CI/badge.svg)](https://github.com/readmeio/readme-node)
 
 [![](https://d3vv6lp55qjaqc.cloudfront.net/items/1M3C3j0I0s0j3T362344/Untitled-2.png)](https://readme.io)
 
@@ -26,15 +26,15 @@ app.use(readme.metrics('<<apiKey>>', req => ({
 })));
 ```
 
-View full documentation here: [https://readme.readme.io/v2.0/docs/sending-logs-to-readme-with-nodejs](https://readme.readme.io/v2.0/docs/sending-logs-to-readme-with-nodejs)
+View full documentation here: [https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs](https://docs.readme.com/docs/sending-logs-to-readme-with-nodejs)
 
 
 ### Limitations
-- Currently only supports JSON. Adding a whitelist/blacklist for non-json bodies will not work (unless they're added to `req.body`)
-the same way that `body-parser` does it. The properties will be converted to JSON in the har format.
-- Needs more support for getting URL when behind a reverse proxy: x-forwarded-for, x-forwarded-proto etc
-- Needs more support for getting client ip address when behind a reverse proxy
-- Logs are "fire and forget" to the metrics server, so any failed requests (even for incorrect API key!) will currently fail
+- Currently only supports JSON. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`)
+the same way that `body-parser` does it. The properties will be converted to JSON in the HAR format.
+- Needs more support for getting URLs when behind a reverse proxy: `x-forwarded-for`, `x-forwarded-proto`, etc.
+- Needs more support for getting client IP address when behind a reverse proxy.
+- Logs are "fire and forget" to the metrics server, so any failed requests (even for incorrect API key!) will currently fail silently.
 
 ## Credits
 [Dom Harrington](https://github.com/domharrington/)

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -21,7 +21,7 @@ module.exports = (req, options = {}) => {
       pathname: `${req.baseUrl}${req.path}`,
       query: req.query,
     }),
-    httpVersion: req.httpVersion,
+    httpVersion: `${req.protocol.toUpperCase()}/${req.httpVersion}`,
     headers: objectToArray(req.headers),
     queryString: objectToArray(req.query),
     postData: {

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -87,7 +87,7 @@ describe('processRequest()', () => {
   it('#httpVersion', () =>
     request(createApp())
       .post('/')
-      .expect(({ body }) => expect(body.httpVersion).toBe('1.1')));
+      .expect(({ body }) => expect(body.httpVersion).toBe('HTTP/1.1')));
 
   it('#headers', () =>
     request(createApp())


### PR DESCRIPTION
[Per the HAR spec](https://github.com/ahmadnassri/har-spec/blob/master/versions/1.3.md#request), `httpVersion` should be the fully qualified protocol+revision, not just the revision.