### PR TITLE
Fix omit for nested objects

### DIFF
--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -1,6 +1,6 @@
 const url = require('url');
-const removeProperties = require('lodash.omit');
-const removeOtherProperties = require('lodash.pick');
+const removeProperties = require('lodash/omit');
+const removeOtherProperties = require('lodash/pick');
 
 const objectToArray = require('./object-to-array');
 

--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -1,5 +1,5 @@
-const removeProperties = require('lodash.omit');
-const removeOtherProperties = require('lodash.pick');
+const removeProperties = require('lodash/omit');
+const removeOtherProperties = require('lodash/pick');
 
 const objectToArray = require('./object-to-array');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5615,8 +5615,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -5672,20 +5671,10 @@
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.snakecase": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "dependencies": {
     "configly": "^4.1.0",
     "jsonwebtoken": "^8.3.0",
-    "lodash.omit": "^4.5.0",
-    "lodash.pick": "^4.4.0",
+    "lodash": "^4.17.15",
     "node-uuid": "^1.4.8",
     "r2": "^2.0.1"
   },

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -34,6 +34,17 @@ describe('processRequest()', () => {
         });
     });
 
+    it('should strip blacklisted nested properties', () => {
+      const app = createApp({ blacklist: ['a.b.c'] });
+
+      return request(app)
+        .post('/')
+        .send({ a: { b: { c: 1 } } })
+        .expect(({ body }) => {
+          expect(body.postData.params).toStrictEqual([{ name: 'a', value: { b: {} } }]);
+        });
+    });
+
     it('should only send whitelisted properties', () => {
       const app = createApp({ whitelist: ['password', 'apiKey'] });
 
@@ -45,6 +56,17 @@ describe('processRequest()', () => {
             { name: 'password', value: '123456' },
             { name: 'apiKey', value: 'abcdef' },
           ]);
+        });
+    });
+
+    it('should only send whitelisted nested properties', () => {
+      const app = createApp({ whitelist: ['a.b.c'] });
+
+      return request(app)
+        .post('/')
+        .send({ a: { b: { c: 1 } }, d: 2 })
+        .expect(({ body }) => {
+          expect(body.postData.params).toStrictEqual([{ name: 'a', value: { b: { c: 1 } } }]);
         });
     });
   });

--- a/test/process-response.test.js
+++ b/test/process-response.test.js
@@ -33,6 +33,15 @@ describe('processResponse()', () => {
       }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
     });
 
+    it('should strip blacklisted nested properties', () => {
+      expect.hasAssertions();
+      return testResponse(res => {
+        expect(processResponse(res, { blacklist: ['a.b.c'] }).content.text).toStrictEqual(
+          JSON.stringify({ a: { b: {} } })
+        );
+      }, JSON.stringify({ a: { b: { c: 1 } } }));
+    });
+
     it('should only send whitelisted properties', () => {
       expect.hasAssertions();
       return testResponse(res => {
@@ -40,6 +49,15 @@ describe('processResponse()', () => {
           JSON.stringify({ password: '123456', apiKey: 'abcdef' })
         );
       }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
+    });
+
+    it('should only send whitelisted nested properties', () => {
+      expect.hasAssertions();
+      return testResponse(res => {
+        expect(processResponse(res, { whitelist: ['a.b.c'] }).content.text).toStrictEqual(
+          JSON.stringify({ a: { b: { c: 1 } } })
+        );
+      }, JSON.stringify({ a: { b: { c: 1 } }, d: 2 }));
     });
 
     it('should not be applied for plain text bodies', () => {


### PR DESCRIPTION
We’re using the dedicated `lodash.omit` package from npm to reduce our bundle size. But it looks like the smaller npm modules are out of date:
https://github.com/lodash/lodash/issues/4254
https://github.com/lodash/lodash/issues/4193
https://github.com/lodash/lodash/issues/4030

Can confirm this works when using the full lodash@4.17.15  module, and not the lodash.omit@4.5.0 module.
```
const omit = require('lodash.omit');
 omit({ a: { b: { c: 1 } } }, ['a.b.c'])
 { a: { b: { c: 1 } } }

const omit = require('lodash/omit');
 omit({ a: { b: { c: 1 } } }, ['a.b.c'])
 { a: { b: {} } }
```