### PR TITLE
feature: Blacklist/Whitelist headers

### DIFF
--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -6,11 +6,13 @@ const objectToArray = require('./object-to-array');
 
 module.exports = (req, options = {}) => {
   if (options.blacklist) {
-    req.body = removeProperties(req.body, options.blacklist);
+    if (options.blacklist.body) req.body = removeProperties(req.body, options.blacklist.body);
+    if (options.blacklist.headers) req.headers = removeProperties(req.headers, options.blacklist.headers);
   }
 
   if (options.whitelist) {
-    req.body = removeOtherProperties(req.body, options.whitelist);
+    if (options.whitelist.body) req.body = removeOtherProperties(req.body, options.whitelist.body);
+    if (options.whitelist.headers) req.headers = removeOtherProperties(req.headers, options.whitelist.headers);
   }
 
   return {

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -10,7 +10,7 @@ module.exports = (req, options = {}) => {
     req.headers = removeProperties(req.headers, options.blacklist);
   }
 
-  if (options.whitelist) {
+  if (options.whitelist && !options.blacklist) {
     req.body = removeOtherProperties(req.body, options.whitelist);
     req.headers = removeOtherProperties(req.headers, options.whitelist);
   }

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -6,13 +6,13 @@ const objectToArray = require('./object-to-array');
 
 module.exports = (req, options = {}) => {
   if (options.blacklist) {
-    if (options.blacklist.body) req.body = removeProperties(req.body, options.blacklist.body);
-    if (options.blacklist.headers) req.headers = removeProperties(req.headers, options.blacklist.headers);
+    req.body = removeProperties(req.body, options.blacklist);
+    req.headers = removeProperties(req.headers, options.blacklist);
   }
 
   if (options.whitelist) {
-    if (options.whitelist.body) req.body = removeOtherProperties(req.body, options.whitelist.body);
-    if (options.whitelist.headers) req.headers = removeOtherProperties(req.headers, options.whitelist.headers);
+    req.body = removeOtherProperties(req.body, options.whitelist);
+    req.headers = removeOtherProperties(req.headers, options.whitelist);
   }
 
   return {

--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -13,12 +13,12 @@ module.exports = (res, options = {}) => {
     body = JSON.parse(res._body);
 
     // Only apply blacklist/whitelist if it's an object
-    if (options.blacklist && options.blacklist.body) {
-      body = removeProperties(body, options.blacklist.body);
+    if (options.blacklist) {
+      body = removeProperties(body, options.blacklist);
     }
 
-    if (options.whitelist && options.whitelist.body) {
-      body = removeOtherProperties(body, options.whitelist.body);
+    if (options.whitelist) {
+      body = removeOtherProperties(body, options.whitelist);
     }
   } catch (e) {
     // Non JSON body
@@ -27,12 +27,12 @@ module.exports = (res, options = {}) => {
 
   let headers = res.getHeaders();
 
-  if (options.blacklist && options.blacklist.headers) {
-    headers = removeProperties(headers, options.blacklist.headers);
+  if (options.blacklist) {
+    headers = removeProperties(headers, options.blacklist);
   }
 
-  if (options.whitelist && options.whitelist.headers) {
-    headers = removeOtherProperties(headers, options.whitelist.headers);
+  if (options.whitelist) {
+    headers = removeOtherProperties(headers, options.whitelist);
   }
 
   return {

--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -17,7 +17,7 @@ module.exports = (res, options = {}) => {
       body = removeProperties(body, options.blacklist);
     }
 
-    if (options.whitelist) {
+    if (options.whitelist && !options.blacklist) {
       body = removeOtherProperties(body, options.whitelist);
     }
   } catch (e) {
@@ -31,7 +31,7 @@ module.exports = (res, options = {}) => {
     headers = removeProperties(headers, options.blacklist);
   }
 
-  if (options.whitelist) {
+  if (options.whitelist && !options.blacklist) {
     headers = removeOtherProperties(headers, options.whitelist);
   }
 

--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -13,22 +13,32 @@ module.exports = (res, options = {}) => {
     body = JSON.parse(res._body);
 
     // Only apply blacklist/whitelist if it's an object
-    if (options.blacklist) {
-      body = removeProperties(body, options.blacklist);
+    if (options.blacklist && options.blacklist.body) {
+      body = removeProperties(body, options.blacklist.body);
     }
 
-    if (options.whitelist) {
-      body = removeOtherProperties(body, options.whitelist);
+    if (options.whitelist && options.whitelist.body) {
+      body = removeOtherProperties(body, options.whitelist.body);
     }
   } catch (e) {
     // Non JSON body
     body = res._body;
   }
 
+  let headers = res.getHeaders();
+
+  if (options.blacklist && options.blacklist.headers) {
+    headers = removeProperties(headers, options.blacklist.headers);
+  }
+
+  if (options.whitelist && options.whitelist.headers) {
+    headers = removeOtherProperties(headers, options.whitelist.headers);
+  }
+
   return {
     status: res.statusCode,
     statusText: res.statusMessage,
-    headers: objectToArray(res.getHeaders()),
+    headers: objectToArray(headers),
     content: {
       text: JSON.stringify(body),
       size: res.get('content-length') || 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readmeio",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/construct-payload.test.js
+++ b/test/construct-payload.test.js
@@ -24,7 +24,7 @@ function createApp(options, existingPayload = { startedDateTime: new Date() }) {
 
 describe('constructPayload()', () => {
   it('should construct a har file from the request/response', () => {
-    return request(createApp({ blacklist: { body: ['password'] } }))
+    return request(createApp({ blacklist:['password'] }))
       .post('/')
       .send({ password: '123456' })
       .expect(({ body }) => {

--- a/test/construct-payload.test.js
+++ b/test/construct-payload.test.js
@@ -24,7 +24,7 @@ function createApp(options, existingPayload = { startedDateTime: new Date() }) {
 
 describe('constructPayload()', () => {
   it('should construct a har file from the request/response', () => {
-    return request(createApp({ blacklist: ['password'] }))
+    return request(createApp({ blacklist: { body: ['password'] } }))
       .post('/')
       .send({ password: '123456' })
       .expect(({ body }) => {

--- a/test/construct-payload.test.js
+++ b/test/construct-payload.test.js
@@ -24,7 +24,7 @@ function createApp(options, existingPayload = { startedDateTime: new Date() }) {
 
 describe('constructPayload()', () => {
   it('should construct a har file from the request/response', () => {
-    return request(createApp({ blacklist:['password'] }))
+    return request(createApp({ blacklist: ['password'] }))
       .post('/')
       .send({ password: '123456' })
       .expect(({ body }) => {

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -25,7 +25,7 @@ describe('processRequest()', () => {
   describe('options', () => {
     describe('blacklist/whitelist in body', () => {
       it('should strip blacklisted properties', () => {
-        const app = createApp({ blacklist: { body: ['password', 'apiKey'] } });
+        const app = createApp({ blacklist: ['password', 'apiKey'] });
 
         return request(app)
           .post('/')
@@ -36,7 +36,7 @@ describe('processRequest()', () => {
       });
 
       it('should strip blacklisted nested properties', () => {
-        const app = createApp({ blacklist: { body: ['a.b.c'] } });
+        const app = createApp({ blacklist: ['a.b.c'] });
 
         return request(app)
           .post('/')
@@ -47,7 +47,7 @@ describe('processRequest()', () => {
       });
 
       it('should only send whitelisted properties', () => {
-        const app = createApp({ whitelist: { body: ['password', 'apiKey'] } });
+        const app = createApp({ whitelist: ['password', 'apiKey'] });
 
         return request(app)
           .post('/')
@@ -61,7 +61,7 @@ describe('processRequest()', () => {
       });
 
       it('should only send whitelisted nested properties', () => {
-        const app = createApp({ whitelist: { body: ['a.b.c'] } });
+        const app = createApp({ whitelist: ['a.b.c'] });
 
         return request(app)
           .post('/')
@@ -74,7 +74,7 @@ describe('processRequest()', () => {
 
     describe('blacklist/whitelist in headers', () => {
       it('should strip blacklisted properties', () => {
-        const app = createApp({ blacklist: { headers: ['host', 'accept-encoding', 'user-agent', 'connection'] } });
+        const app = createApp({ blacklist: ['host', 'accept-encoding', 'user-agent', 'connection'] });
 
         return request(app)
           .post('/')
@@ -88,7 +88,7 @@ describe('processRequest()', () => {
       });
 
       it('should only send whitelisted properties', () => {
-        const app = createApp({ whitelist: { headers: ['a'] } });
+        const app = createApp({ whitelist: ['a'] });
 
         return request(app)
           .post('/')

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -70,6 +70,17 @@ describe('processRequest()', () => {
             expect(body.postData.params).toStrictEqual([{ name: 'a', value: { b: { c: 1 } } }]);
           });
       });
+
+      it('should ignore whitelist if blacklist is present', () => {
+        const app = createApp({ blacklist: ['password', 'apiKey'], whitelist: ['password', 'apiKey'] });
+
+        return request(app)
+          .post('/')
+          .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
+          .expect(({ body }) => {
+            expect(body.postData.params).toStrictEqual([{ name: 'another', value: 'Hello world' }]);
+          });
+      });
     });
 
     describe('blacklist/whitelist in headers', () => {

--- a/test/process-response.test.js
+++ b/test/process-response.test.js
@@ -60,6 +60,15 @@ describe('processResponse()', () => {
           );
         }, JSON.stringify({ a: { b: { c: 1 } }, d: 2 }));
       });
+
+      it('should ignore whitelist if blacklist is present', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(
+            processResponse(res, { blacklist: ['password', 'apiKey'], whitelist: ['password', 'apiKey'] }).content.text
+          ).toStrictEqual(JSON.stringify({ another: 'Hello world' }));
+        }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
+      });
     });
 
     describe('blacklist/whitelist in headers', () => {

--- a/test/process-response.test.js
+++ b/test/process-response.test.js
@@ -24,40 +24,62 @@ async function testResponse(assertion, response) {
 
 describe('processResponse()', () => {
   describe('options', () => {
-    it('should strip blacklisted properties', () => {
-      expect.hasAssertions();
-      return testResponse(res => {
-        expect(processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text).toStrictEqual(
-          JSON.stringify({ another: 'Hello world' })
-        );
-      }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
+    describe('blacklist/whitelist in body', () => {
+      it('should strip blacklisted properties in body', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(processResponse(res, { blacklist: { body: ['password', 'apiKey'] } }).content.text).toStrictEqual(
+            JSON.stringify({ another: 'Hello world' })
+          );
+        }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
+      });
+
+      it('should strip blacklisted nested properties in body', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(processResponse(res, { blacklist: { body: ['a.b.c'] } }).content.text).toStrictEqual(
+            JSON.stringify({ a: { b: {} } })
+          );
+        }, JSON.stringify({ a: { b: { c: 1 } } }));
+      });
+
+      it('should only send whitelisted properties in body', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(processResponse(res, { whitelist: { body: ['password', 'apiKey'] } }).content.text).toStrictEqual(
+            JSON.stringify({ password: '123456', apiKey: 'abcdef' })
+          );
+        }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
+      });
+
+      it('should only send whitelisted nested properties in body', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(processResponse(res, { whitelist: { body: ['a.b.c'] } }).content.text).toStrictEqual(
+            JSON.stringify({ a: { b: { c: 1 } } })
+          );
+        }, JSON.stringify({ a: { b: { c: 1 } }, d: 2 }));
+      });
     });
 
-    it('should strip blacklisted nested properties', () => {
-      expect.hasAssertions();
-      return testResponse(res => {
-        expect(processResponse(res, { blacklist: ['a.b.c'] }).content.text).toStrictEqual(
-          JSON.stringify({ a: { b: {} } })
-        );
-      }, JSON.stringify({ a: { b: { c: 1 } } }));
-    });
+    describe('blacklist/whitelist in headers', () => {
+      it('should strip blacklisted properties in headers', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(
+            processResponse(res, { blacklist: { headers: ['content-length', 'etag', 'content-type'] } }).headers
+          ).toStrictEqual([{ name: 'x-powered-by', value: 'Express' }]);
+        });
+      });
 
-    it('should only send whitelisted properties', () => {
-      expect.hasAssertions();
-      return testResponse(res => {
-        expect(processResponse(res, { whitelist: ['password', 'apiKey'] }).content.text).toStrictEqual(
-          JSON.stringify({ password: '123456', apiKey: 'abcdef' })
-        );
-      }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
-    });
-
-    it('should only send whitelisted nested properties', () => {
-      expect.hasAssertions();
-      return testResponse(res => {
-        expect(processResponse(res, { whitelist: ['a.b.c'] }).content.text).toStrictEqual(
-          JSON.stringify({ a: { b: { c: 1 } } })
-        );
-      }, JSON.stringify({ a: { b: { c: 1 } }, d: 2 }));
+      it('should only send whitelisted properties in headers', () => {
+        expect.hasAssertions();
+        return testResponse(res => {
+          expect(processResponse(res, { whitelist: { headers: ['x-powered-by'] } }).headers).toStrictEqual([
+            { name: 'x-powered-by', value: 'Express' },
+          ]);
+        });
+      });
     });
 
     it('should not be applied for plain text bodies', () => {

--- a/test/process-response.test.js
+++ b/test/process-response.test.js
@@ -28,7 +28,7 @@ describe('processResponse()', () => {
       it('should strip blacklisted properties in body', () => {
         expect.hasAssertions();
         return testResponse(res => {
-          expect(processResponse(res, { blacklist: { body: ['password', 'apiKey'] } }).content.text).toStrictEqual(
+          expect(processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text).toStrictEqual(
             JSON.stringify({ another: 'Hello world' })
           );
         }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
@@ -37,7 +37,7 @@ describe('processResponse()', () => {
       it('should strip blacklisted nested properties in body', () => {
         expect.hasAssertions();
         return testResponse(res => {
-          expect(processResponse(res, { blacklist: { body: ['a.b.c'] } }).content.text).toStrictEqual(
+          expect(processResponse(res, { blacklist: ['a.b.c'] }).content.text).toStrictEqual(
             JSON.stringify({ a: { b: {} } })
           );
         }, JSON.stringify({ a: { b: { c: 1 } } }));
@@ -46,7 +46,7 @@ describe('processResponse()', () => {
       it('should only send whitelisted properties in body', () => {
         expect.hasAssertions();
         return testResponse(res => {
-          expect(processResponse(res, { whitelist: { body: ['password', 'apiKey'] } }).content.text).toStrictEqual(
+          expect(processResponse(res, { whitelist: ['password', 'apiKey'] }).content.text).toStrictEqual(
             JSON.stringify({ password: '123456', apiKey: 'abcdef' })
           );
         }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
@@ -55,7 +55,7 @@ describe('processResponse()', () => {
       it('should only send whitelisted nested properties in body', () => {
         expect.hasAssertions();
         return testResponse(res => {
-          expect(processResponse(res, { whitelist: { body: ['a.b.c'] } }).content.text).toStrictEqual(
+          expect(processResponse(res, { whitelist: ['a.b.c'] }).content.text).toStrictEqual(
             JSON.stringify({ a: { b: { c: 1 } } })
           );
         }, JSON.stringify({ a: { b: { c: 1 } }, d: 2 }));
@@ -67,7 +67,7 @@ describe('processResponse()', () => {
         expect.hasAssertions();
         return testResponse(res => {
           expect(
-            processResponse(res, { blacklist: { headers: ['content-length', 'etag', 'content-type'] } }).headers
+            processResponse(res, { blacklist: ['content-length', 'etag', 'content-type'] }).headers
           ).toStrictEqual([{ name: 'x-powered-by', value: 'Express' }]);
         });
       });
@@ -75,7 +75,7 @@ describe('processResponse()', () => {
       it('should only send whitelisted properties in headers', () => {
         expect.hasAssertions();
         return testResponse(res => {
-          expect(processResponse(res, { whitelist: { headers: ['x-powered-by'] } }).headers).toStrictEqual([
+          expect(processResponse(res, { whitelist: ['x-powered-by'] }).headers).toStrictEqual([
             { name: 'x-powered-by', value: 'Express' },
           ]);
         });


### PR DESCRIPTION
🚨 **Potentially Breaking Change Alert!**

## 🧰 What's being changed?
Adding the ability to black/whitelist request and response headers! Now the `blacklist` and `whitelist` options also apply the filtering to headers.

## 💭 Outstanding Questions
- [x] Should I do this in a way that is non-breaking? I was thinking `options.blacklistHeaders` or something like that but it seems somewhat inelegant
- [x] I don't need tests for "nested" headers, right? Is that even a thing?
- [ ] Are there certain headers that we shouldn't allow users to exclude? Stuff like: https://github.com/readmeio/readme-node/blob/7d353c7a8d0dac75dcb4d744e2a18f11143a4461/lib/process-request.js#L21-L22