### PR TITLE
fix: use correct mimeType instead of always specifying JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ View full documentation here: [https://docs.readme.com/docs/sending-logs-to-read
 
 
 ### Limitations
-- Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`)
-the same way that `body-parser` does it. The properties will be passed into the HAR `postData` as both JSON-stringified `text` and a HAR-formatted `params` array. See [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1049080#c6) for info on why both `params` and `text` are being delivered.
+- Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`) the same way that `body-parser` does it. The properties will be passed into [`postData`](http://www.softwareishard.com/blog/har-12-spec/#postData) as a `params` array.
 - Needs more support for getting URLs when behind a reverse proxy: `x-forwarded-for`, `x-forwarded-proto`, etc.
 - Needs more support for getting client IP address when behind a reverse proxy.
 - Logs are "fire and forget" to the metrics server, so any failed requests (even for incorrect API key!) will currently fail silently.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ View full documentation here: [https://docs.readme.com/docs/sending-logs-to-read
 
 
 ### Limitations
-- Currently only supports JSON. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`)
-the same way that `body-parser` does it. The properties will be converted to JSON in the HAR format.
+- Currently only supports JSON request bodies. Adding a whitelist/blacklist for non-JSON bodies will not work (unless they're added to `req.body`)
+the same way that `body-parser` does it. The properties will be passed into the HAR `postData` as both JSON-stringified `text` and a HAR-formatted `params` array. See [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1049080#c6) for info on why both `params` and `text` are being delivered.
 - Needs more support for getting URLs when behind a reverse proxy: `x-forwarded-for`, `x-forwarded-proto`, etc.
 - Needs more support for getting client IP address when behind a reverse proxy.
 - Logs are "fire and forget" to the metrics server, so any failed requests (even for incorrect API key!) will currently fail silently.

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -35,7 +35,6 @@ module.exports = (req, options = {}) => {
     postData: {
       mimeType,
       params: objectToArray(req.body || {}),
-      text: req.body ? JSON.stringify(req.body) : '',
     },
   };
 };

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -1,6 +1,7 @@
 const url = require('url');
 const removeProperties = require('lodash/omit');
 const removeOtherProperties = require('lodash/pick');
+const contentType = require('content-type');
 
 const objectToArray = require('./object-to-array');
 
@@ -15,6 +16,11 @@ module.exports = (req, options = {}) => {
     req.headers = removeOtherProperties(req.headers, options.whitelist);
   }
 
+  let mimeType = 'application/json';
+  try {
+    mimeType = contentType.parse(req).type;
+  } catch (e) {} // eslint-disable-line no-empty
+
   return {
     method: req.method,
     url: url.format({
@@ -27,8 +33,9 @@ module.exports = (req, options = {}) => {
     headers: objectToArray(req.headers),
     queryString: objectToArray(req.query),
     postData: {
-      mimeType: 'application/json',
+      mimeType,
       params: objectToArray(req.body || {}),
+      text: req.body ? JSON.stringify(req.body) : '',
     },
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readmeio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2057,8 +2057,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "conventional-changelog": {
       "version": "3.1.18",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=10"
   },
   "dependencies": {
+    "content-type": "^1.0.4",
     "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.15",
     "node-uuid": "^1.4.8",

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -255,14 +255,6 @@ describe('processRequest()', () => {
           .send('a=1&b=2')
           .expect(res => expect(res.body.postData.mimeType).toBe('application/x-www-form-urlencoded'));
       });
-
-      it('#text should be JSON-stringified body', () => {
-        return request(createApp())
-          .post('/')
-          .set({ name: 'content-type', value: 'application/x-www-form-urlencoded' })
-          .send('a=1&b=2')
-          .expect(res => expect(res.body.postData.text).toBe('{"a":"1","b":"2"}'));
-      });
     });
 
     it('#mimeType should default to application/json', () =>
@@ -281,14 +273,6 @@ describe('processRequest()', () => {
             { name: 'b', value: 2 },
           ])
         );
-    });
-
-    it('#text should be JSON-stringified body', () => {
-      const body = { a: 1, b: 2 };
-      return request(createApp())
-        .post('/')
-        .send(body)
-        .expect(res => expect(res.body.postData.text).toBe('{"a":1,"b":2}'));
     });
   });
 });

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -6,6 +6,7 @@ const processRequest = require('../lib/process-request');
 
 function createApp(options) {
   const app = express();
+  app.use(bodyParser.urlencoded({ extended: false }));
   app.use(bodyParser.json());
 
   const router = express.Router();
@@ -233,12 +234,43 @@ describe('processRequest()', () => {
       ));
 
   describe('#postData', () => {
-    it('#mimeType should be application/json', () =>
+    describe('application/x-www-form-urlencoded', () => {
+      it('#params should contain parsed body', () => {
+        return request(createApp())
+          .post('/')
+          .set({ name: 'content-type', value: 'application/x-www-form-urlencoded' })
+          .send('a=1&b=2')
+          .expect(res =>
+            expect(res.body.postData.params).toStrictEqual([
+              { name: 'a', value: '1' },
+              { name: 'b', value: '2' },
+            ])
+          );
+      });
+
+      it('#mimeType should properly parse content-type header', () => {
+        return request(createApp())
+          .post('/')
+          .set({ name: 'content-type', value: 'application/x-www-form-urlencoded; charset=UTF-8' })
+          .send('a=1&b=2')
+          .expect(res => expect(res.body.postData.mimeType).toBe('application/x-www-form-urlencoded'));
+      });
+
+      it('#text should be JSON-stringified body', () => {
+        return request(createApp())
+          .post('/')
+          .set({ name: 'content-type', value: 'application/x-www-form-urlencoded' })
+          .send('a=1&b=2')
+          .expect(res => expect(res.body.postData.text).toBe('{"a":"1","b":"2"}'));
+      });
+    });
+
+    it('#mimeType should default to application/json', () =>
       request(createApp())
         .post('/')
         .expect(({ body }) => expect(body.postData.mimeType).toBe('application/json')));
 
-    it('#text should be stringified body', () => {
+    it('#params should contain parsed body', () => {
       const body = { a: 1, b: 2 };
       return request(createApp())
         .post('/')
@@ -249,6 +281,14 @@ describe('processRequest()', () => {
             { name: 'b', value: 2 },
           ])
         );
+    });
+
+    it('#text should be JSON-stringified body', () => {
+      const body = { a: 1, b: 2 };
+      return request(createApp())
+        .post('/')
+        .send(body)
+        .expect(res => expect(res.body.postData.text).toBe('{"a":1,"b":2}'));
     });
   });
 });


### PR DESCRIPTION
After thinking about this some more, I've made the following changes to how we construct the HAR `postData` payload:
- Pass in both `params` and `text` versions of `req.body`. I was inspired by this [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1049080#c6) where they ultimately decided that passing in both was more robust, even if it technically violates the HAR spec.
- Parse the `content-type` header and pass the [`media-type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#Directives) as the `mimeType` (and defaulting to `application/json`). Based on my interpretation of the [spec](http://www.softwareishard.com/blog/har-12-spec/#postData), we shouldn't include the full `content-type` header here.

#### Note about `text`
I also think it's fine that we're JSON-stringifying `req.body` in `text`, since the [HAR spec specifies](http://www.softwareishard.com/blog/har-12-spec/#postData) that URL-encoded parameters should be taken from the `params` anyways.