### PR TITLE
fix: use postData.text for JSON to handle nested body content

### DIFF
--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -25,7 +25,9 @@ module.exports = (req, options = {}) => {
   // Per HAR, we send JSON as postData.text, not params.
   if (postData.mimeType === 'application/json') {
     postData.text = JSON.stringify(req.body);
-  } else postData.params = objectToArray(req.body || {});
+  } else {
+    postData.params = objectToArray(req.body || {});
+  }
 
   return {
     method: req.method,

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -16,10 +16,16 @@ module.exports = (req, options = {}) => {
     req.headers = removeOtherProperties(req.headers, options.whitelist);
   }
 
-  let mimeType = 'application/json';
+  // parse mimetype from content-type header, default to JSON
+  const postData = { mimeType: 'application/json' };
   try {
-    mimeType = contentType.parse(req).type;
+    postData.mimeType = contentType.parse(req).type;
   } catch (e) {} // eslint-disable-line no-empty
+
+  // Per HAR, we send JSON as postData.text, not params.
+  if (postData.mimeType === 'application/json') {
+    postData.text = JSON.stringify(req.body);
+  } else postData.params = objectToArray(req.body || {});
 
   return {
     method: req.method,
@@ -32,9 +38,6 @@ module.exports = (req, options = {}) => {
     httpVersion: `${req.protocol.toUpperCase()}/${req.httpVersion}`,
     headers: objectToArray(req.headers),
     queryString: objectToArray(req.query),
-    postData: {
-      mimeType,
-      params: objectToArray(req.body || {}),
-    },
+    postData,
   };
 };

--- a/test/construct-payload.test.js
+++ b/test/construct-payload.test.js
@@ -30,9 +30,7 @@ describe('constructPayload()', () => {
       .expect(({ body }) => {
         expect(typeof body.request.log.entries[0].request).toBe('object');
         expect(typeof body.request.log.entries[0].response).toBe('object');
-        expect(
-          body.request.log.entries[0].request.postData.params.find(param => param.name === 'password')
-        ).toBeUndefined();
+        expect(body.request.log.entries[0].request.postData.text).toBe('{}');
       });
   }, 8000);
 

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -32,7 +32,7 @@ describe('processRequest()', () => {
           .post('/')
           .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.params).toStrictEqual([{ name: 'another', value: 'Hello world' }]);
+            expect(body.postData.text).toBe('{"another":"Hello world"}');
           });
       });
 
@@ -43,7 +43,7 @@ describe('processRequest()', () => {
           .post('/')
           .send({ a: { b: { c: 1 } } })
           .expect(({ body }) => {
-            expect(body.postData.params).toStrictEqual([{ name: 'a', value: { b: {} } }]);
+            expect(body.postData.text).toBe('{"a":{"b":{}}}');
           });
       });
 
@@ -54,10 +54,7 @@ describe('processRequest()', () => {
           .post('/')
           .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.params).toStrictEqual([
-              { name: 'password', value: '123456' },
-              { name: 'apiKey', value: 'abcdef' },
-            ]);
+            expect(body.postData.text).toBe('{"password":"123456","apiKey":"abcdef"}');
           });
       });
 
@@ -68,7 +65,7 @@ describe('processRequest()', () => {
           .post('/')
           .send({ a: { b: { c: 1 } }, d: 2 })
           .expect(({ body }) => {
-            expect(body.postData.params).toStrictEqual([{ name: 'a', value: { b: { c: 1 } } }]);
+            expect(body.postData.text).toBe('{"a":{"b":{"c":1}}}');
           });
       });
 
@@ -79,7 +76,7 @@ describe('processRequest()', () => {
           .post('/')
           .send({ password: '123456', apiKey: 'abcdef', another: 'Hello world' })
           .expect(({ body }) => {
-            expect(body.postData.params).toStrictEqual([{ name: 'another', value: 'Hello world' }]);
+            expect(body.postData.text).toBe('{"another":"Hello world"}');
           });
       });
     });
@@ -126,7 +123,7 @@ describe('processRequest()', () => {
               { name: 'content-type', value: 'application/json' },
               { name: 'a', value: '1' },
             ]);
-            expect(body.postData.params).toStrictEqual([{ name: 'another', value: 'Hello world' }]);
+            expect(body.postData.text).toBe('{"another":"Hello world"}');
           });
       });
 
@@ -144,7 +141,7 @@ describe('processRequest()', () => {
               { name: 'a', value: '1' },
               { name: 'content-type', value: 'application/json' },
             ]);
-            expect(body.postData.params).toStrictEqual([{ name: 'another', value: 'Hello world' }]);
+            expect(body.postData.text).toBe('{"another":"Hello world"}');
           });
       });
 
@@ -163,7 +160,7 @@ describe('processRequest()', () => {
               { name: 'content-type', value: 'application/json' },
               { name: 'a', value: '1' },
             ]);
-            expect(body.postData.params).toStrictEqual([{ name: 'another', value: 'Hello world' }]);
+            expect(body.postData.text).toBe('{"another":"Hello world"}');
           });
       });
     });
@@ -267,12 +264,7 @@ describe('processRequest()', () => {
       return request(createApp())
         .post('/')
         .send(body)
-        .expect(res =>
-          expect(res.body.postData.params).toStrictEqual([
-            { name: 'a', value: 1 },
-            { name: 'b', value: 2 },
-          ])
-        );
+        .expect(res => expect(res.body.postData.text).toBe('{"a":1,"b":2}'));
     });
   });
 });


### PR DESCRIPTION
After talking with @domharrington and @erunion and seeing issues with nested object content (e.g. `{ a: { b: 1 } }`) where param values were getting set to objects when they should only be strings, I updated our request processing so we're using `postData.text` to store JSON request bodies, instead of `postData.params`.

We had decided in https://github.com/readmeio/readme-node/pull/64 to use `postData.params` (when I had [originally proposed](https://github.com/readmeio/readme-node/pull/64#issue-404520760) using both `params` and `text`) to avoid duplicate data and make the data more readable, but `text` more compliant with HAR and it allows us to store nested request body content properly.