### PR TITLE
chore(deps): replacing node-uuid with uuid

### DIFF
--- a/lib/create-jwt-link.js
+++ b/lib/create-jwt-link.js
@@ -1,5 +1,5 @@
 const getReadmeData = require('./get-readme-data');
-const uuid = require('node-uuid');
+const { v4 } = require('uuid');
 const jwt = require('jsonwebtoken');
 
 module.exports = async (apiKey, user, redirectPath = '') => {
@@ -11,7 +11,7 @@ module.exports = async (apiKey, user, redirectPath = '') => {
   }
 
   const jwtOptions = {
-    jwtid: uuid.v4(),
+    jwtid: v4(),
   };
 
   let token = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7430,11 +7430,6 @@
         }
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -8209,6 +8204,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -9350,6 +9351,14 @@
       "requires": {
         "temp-dir": "^2.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "terminal-link": {
@@ -9714,10 +9723,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "content-type": "^1.0.4",
     "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.15",
-    "node-uuid": "^1.4.8",
-    "r2": "^2.0.1"
+    "r2": "^2.0.1",
+    "uuid": "^8.1.0"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
When running unit tests, the following warning appears:

> [SECURITY] node-uuid: crypto not usable, falling back to insecure Math.random()

[node-uuid](https://npm.im/node-uuid) has been deprecated in place of [uuid](https://npm.im/uuid). Since `uuid` is a drop-in replacement, I've swapped it in.