### PR TITLE
fix: don't stringify empty post bodies

### DIFF
--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -16,17 +16,20 @@ module.exports = (req, options = {}) => {
     req.headers = removeOtherProperties(req.headers, options.whitelist);
   }
 
-  // parse mimetype from content-type header, default to JSON
-  const postData = { mimeType: 'application/json' };
-  try {
-    postData.mimeType = contentType.parse(req).type;
-  } catch (e) {} // eslint-disable-line no-empty
+  const postData = {};
+  if (Object.keys(req.body).length > 0) {
+    // parse mimetype from content-type header, default to JSON
+    postData.mimeType = 'application/json';
+    try {
+      postData.mimeType = contentType.parse(req).type;
+    } catch (e) {} // eslint-disable-line no-empty
 
-  // Per HAR, we send JSON as postData.text, not params.
-  if (postData.mimeType === 'application/json') {
-    postData.text = JSON.stringify(req.body);
-  } else {
-    postData.params = objectToArray(req.body || {});
+    // Per HAR, we send JSON as postData.text, not params.
+    if (postData.mimeType === 'application/json') {
+      postData.text = JSON.stringify(req.body);
+    } else {
+      postData.params = objectToArray(req.body || {});
+    }
   }
 
   return {

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -17,7 +17,7 @@ module.exports = (req, options = {}) => {
   }
 
   const postData = {};
-  if (Object.keys(req.body).length > 0) {
+  if (req.body && Object.keys(req.body).length > 0) {
     // parse mimetype from content-type header, default to JSON
     postData.mimeType = 'application/json';
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readmeio",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/construct-payload.test.js
+++ b/test/construct-payload.test.js
@@ -30,7 +30,7 @@ describe('constructPayload()', () => {
       .expect(({ body }) => {
         expect(typeof body.request.log.entries[0].request).toBe('object');
         expect(typeof body.request.log.entries[0].response).toBe('object');
-        expect(body.request.log.entries[0].request.postData.text).toBe('{}');
+        expect(body.request.log.entries[0].request.postData).toStrictEqual({});
       });
   }, 8000);
 

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -15,6 +15,8 @@ function createApp(options) {
 
   app.use('/test-base-path', router);
 
+  app.get('/*', (req, res) => res.json(processRequest(req, options)));
+
   app.post('/*', (req, res) => {
     res.json(processRequest(req, options));
   });
@@ -257,7 +259,18 @@ describe('processRequest()', () => {
     it('#mimeType should default to application/json', () =>
       request(createApp())
         .post('/')
+        .send({ a: 1 })
         .expect(({ body }) => expect(body.postData.mimeType).toBe('application/json')));
+
+    it('should be an empty object if request is a GET', () =>
+      request(createApp())
+        .get('/')
+        .expect(({ body }) => expect(body.postData).toStrictEqual({})));
+
+    it('should be an empty object if req.body is empty', () =>
+      request(createApp())
+        .post('/')
+        .expect(({ body }) => expect(body.postData).toStrictEqual({})));
 
     it('#text should contain stringified body', () => {
       const body = { a: 1, b: 2 };


### PR DESCRIPTION
Small fix, but our cURL requests currently look like this for requests with empty request bodies:

![image](https://user-images.githubusercontent.com/8854718/82933174-2928e480-9f4f-11ea-8c61-22d4c6ec7b3e.png)

This adds a check to make sure `req.body` isn't empty before we construct [`postData`](http://www.softwareishard.com/blog/har-12-spec/#postData).